### PR TITLE
Implemented tolerance for Non entities Queryables

### DIFF
--- a/src/ReflectionIT.Mvc.Paging/PagingList.cs
+++ b/src/ReflectionIT.Mvc.Paging/PagingList.cs
@@ -1,29 +1,51 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.EntityFrameworkCore;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.EntityFrameworkCore;
 
-namespace ReflectionIT.Mvc.Paging {
+namespace ReflectionIT.Mvc.Paging
+{
+    public class PagingList
+    {
+        public static async Task<PagingList<T>> CreateAsync<T>(IOrderedQueryable<T> qry, int pageSize, int pageIndex)
+            where T : class
+        {
+            try
+            {
+                var pageCount = (int)Math.Ceiling(await qry.CountAsync() / (double)pageSize);
 
-    public class PagingList {
+                return new PagingList<T>(await qry.Skip((pageIndex - 1) * pageSize).Take(pageSize).ToListAsync(),
+                    pageSize, pageIndex, pageCount);
+            }
+            catch(InvalidOperationException) //If not async methods are not implemented
+            {
 
-        public static async Task<PagingList<T>> CreateAsync<T>(IOrderedQueryable<T> qry, int pageSize, int pageIndex) where T : class {
-            var pageCount = (int)Math.Ceiling(await qry.CountAsync() / (double)pageSize);
+                var pageCount = (int)Math.Ceiling(qry.Count() / (double)pageSize);
 
-            return new PagingList<T>(await qry.Skip((pageIndex - 1) * pageSize).Take(pageSize).ToListAsync(),
-                                        pageSize, pageIndex, pageCount);
+                return new PagingList<T>(qry.Skip((pageIndex - 1) * pageSize).Take(pageSize).ToList(),
+                    pageSize, pageIndex, pageCount);
+            }
         }
 
-        public static async Task<PagingList<T>> CreateAsync<T>(IQueryable<T> qry, int pageSize, int pageIndex, string sortExpression, string defaultSortExpression) where T : class {
-            var pageCount = (int)Math.Ceiling(await qry.CountAsync() / (double)pageSize);
+        public static async Task<PagingList<T>> CreateAsync<T>(IQueryable<T> qry, int pageSize, int pageIndex,
+            string sortExpression, string defaultSortExpression) where T : class
+        {
+            try
+            {
+                var pageCount = (int)Math.Ceiling(await qry.CountAsync() / (double)pageSize);
 
-            return new PagingList<T>(await qry.OrderBy(sortExpression).Skip((pageIndex - 1) * pageSize).Take(pageSize).ToListAsync(),
-                                     pageSize, pageIndex, pageCount, sortExpression, defaultSortExpression);
+                return new PagingList<T>(
+                    await qry.OrderBy(sortExpression).Skip((pageIndex - 1) * pageSize).Take(pageSize).ToListAsync(),
+                    pageSize, pageIndex, pageCount, sortExpression, defaultSortExpression);
+            }
+            catch(InvalidOperationException) //If not async methods are not implemented/is generic qry
+            {
+                var pageCount = (int)Math.Ceiling(qry.Count() / (double)pageSize);
+
+                return new PagingList<T>(
+                    qry.OrderBy(sortExpression).Skip((pageIndex - 1) * pageSize).Take(pageSize).ToList(),
+                    pageSize, pageIndex, pageCount, sortExpression, defaultSortExpression);
+            }
         }
-
-       
-
     }
 }

--- a/src/SampleApp/Controllers/SuppliersController.cs
+++ b/src/SampleApp/Controllers/SuppliersController.cs
@@ -38,7 +38,11 @@ namespace SampleApp.Controllers {
 
             var qry = _context.Suppliers.AsNoTracking().OrderBy(p => p.CompanyName);
 
-            var model = await PagingList.CreateAsync(qry, 10, page);
+            //Remove EntityFramework control
+            var list = await qry.ToListAsync();
+            var qry2 = list.AsQueryable();
+
+            var model = await PagingList.CreateAsync(qry2, 10, page, "ContactName", "ContactName");
 
             return View(model);
         }


### PR DESCRIPTION
The Non entities doesn't have implemented async funcions, and when you try to use async functions, it throws an InvalidOperationException.

So for fix this I added a tryCatch that fallback sync functions. This fix #3 