### PR TITLE
chore: add .net 8 support & drop .net 5

### DIFF
--- a/src/ReflectionIT.Mvc.Paging/ReflectionIT.Mvc.Paging.csproj
+++ b/src/ReflectionIT.Mvc.Paging/ReflectionIT.Mvc.Paging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net6.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<Company>Reflection IT</Company>
 		<Authors>Fons Sonnemans</Authors>
@@ -13,14 +13,14 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<Title>ReflectionIT.Mvc.Paging</Title>
-		<Description>ASP.NET Core 5, 6.0, 7.0 Library to support Paging (including sorting and filtering) for Entity Framework Core and IEnumerableOfT datasources</Description>
+		<Description>ASP.NET Core 6.0, 7.0, 8.0 Library to support Paging (including sorting and filtering) for Entity Framework Core and IEnumerableOfT datasources</Description>
 		<PackageLicenseUrl></PackageLicenseUrl>
 		<PackageProjectUrl>https://github.com/sonnemaf/ReflectionIT.Mvc.Paging</PackageProjectUrl>
 		<PackageTags>ASPNETCore MVC EntityFrameworkCore Paging</PackageTags>
 		<PackageReleaseNotes>
-			.NET 7.0 support and Bootstrap 5 Pager component added
+			.NET 8.0 support
 		</PackageReleaseNotes>
-		<Version>7.0.0.0</Version>
+		<Version>8.0.0.0</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -35,25 +35,23 @@
 		<RazorCompileOnPublish>true</RazorCompileOnPublish>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	</PropertyGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="5.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.*" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.*" />
-	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="6.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.*" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
 	</ItemGroup>
-
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="7.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.*" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
.net 5 out of support
.net 8 going to be released end of november.
the build will probably fail as long there are no non-pre-release nuget packages on the v8 branch