### PR TITLE
.NET 9.0 support added and .NET 6.0, .NET 7.0 support dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ReflectionIT.Mvc.Paging
-ASP.NET Core 5.0, 6.0, 7.0 Paging (including filtering and sorting) solution using Entity Framework Core and IEnumerable<T>
+ASP.NET Core 8.0, 9.0 Paging (including filtering and sorting) solution using Entity Framework Core and IEnumerable<T>
 
 More info: https://reflectionit.nl/blog/2017/paging-in-asp-net-core-mvc-and-entityframework-core
 

--- a/src/ReflectionIT.Mvc.Paging/LinqExtensions.cs
+++ b/src/ReflectionIT.Mvc.Paging/LinqExtensions.cs
@@ -19,13 +19,7 @@ namespace ReflectionIT.Mvc.Paging {
         }
 
         public static IEnumerable<T> OrderBy<T>([NotNull] this IEnumerable<T>? query, string name) {
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(query);
-#else
-            if (query is null) {
-                throw new ArgumentNullException(nameof(query));
-            }
-#endif
 
             var index = 0;
             var a = name.Split(',');

--- a/src/ReflectionIT.Mvc.Paging/ReflectionIT.Mvc.Paging.csproj
+++ b/src/ReflectionIT.Mvc.Paging/ReflectionIT.Mvc.Paging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<Company>Reflection IT</Company>
 		<Authors>Fons Sonnemans</Authors>
@@ -13,14 +13,14 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<Title>ReflectionIT.Mvc.Paging</Title>
-		<Description>ASP.NET Core 6.0, 7.0, 8.0 Library to support Paging (including sorting and filtering) for Entity Framework Core and IEnumerableOfT datasources</Description>
+		<Description>ASP.NET Core 8.0, 9.0 Library to support Paging (including sorting and filtering) for Entity Framework Core and IEnumerableOfT datasources</Description>
 		<PackageLicenseUrl></PackageLicenseUrl>
 		<PackageProjectUrl>https://github.com/sonnemaf/ReflectionIT.Mvc.Paging</PackageProjectUrl>
 		<PackageTags>ASPNETCore MVC EntityFrameworkCore Paging</PackageTags>
 		<PackageReleaseNotes>
-			.NET 8.0 support added and .NET 5.0 support dropped
+			.NET 9.0 support added and .NET 6.0, .NET 7.0 support dropped
 		</PackageReleaseNotes>
-		<Version>8.0.0.0</Version>
+		<Version>9.0.0.0</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -36,25 +36,18 @@
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="6.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.*" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
-	</ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.*" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.*" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.*" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
-    </ItemGroup>
-
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.*" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.*" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="9.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SampleApp/SampleApp.csproj
+++ b/src/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -9,20 +9,15 @@
 		<Folder Include="Areas\Test\Models\" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.*" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.*" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.*" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.*" />
-	</ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.*" />
     </ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.*" />
+	</ItemGroup>
 
     <ItemGroup>
 	  <ProjectReference Include="..\ReflectionIT.Mvc.Paging\ReflectionIT.Mvc.Paging.csproj" />


### PR DESCRIPTION
.net 6 and .net7 are out of support
.net 9 was released in november 2024